### PR TITLE
covers case if v is ancestor of u

### DIFF
--- a/Graphs C++/17  - LCA/LCA using sparse table.cpp
+++ b/Graphs C++/17  - LCA/LCA using sparse table.cpp
@@ -34,6 +34,12 @@ int LCA(int u, int v) {
 			u = Par[u][j];
 		}
 	}
+
+	// if v is ancestor of u
+	if (u == v) {
+		return u;
+	}
+
 	// u and v are on the same level
 	for (int j = M - 1; j >= 0; j--) {
 		if (Par[u][j] != Par[v][j]) {


### PR DESCRIPTION
Sir earlier code does not cover a case when v is ancestor of u So i updated these few lines to handle case , Please check this and correct me if there are any other mistakes

Tree : 
![image](https://user-images.githubusercontent.com/77237092/179227809-a07ca291-3746-4345-869f-b4244f853feb.png)



Before : 
![image](https://user-images.githubusercontent.com/77237092/179227986-1ba0aa91-6851-49e1-8f82-6d8069344dbf.png)


After :
![image](https://user-images.githubusercontent.com/77237092/179227428-64d776ee-345d-4509-a6ab-a7057a00f7b0.png)
